### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TRC-Loop/Mak/security/code-scanning/1](https://github.com/TRC-Loop/Mak/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file to explicitly define the minimal required permissions. Based on the workflow's purpose (checking out code and running Pylint), the `contents: read` permission should suffice. This ensures that the workflow has only the permissions it needs to access and analyze the repository's code without granting unnecessary write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
